### PR TITLE
fix: limine logic to update cmdline now supports non-uki and uki kernles

### DIFF
--- a/home/.chezmoiscripts/linux/helpers/.00_helpers
+++ b/home/.chezmoiscripts/linux/helpers/.00_helpers
@@ -70,26 +70,35 @@ write_system_config() {
 }
 
 create_backup() {
-  local file_path="$1"
+  local target_path="$1"
   local backup_path
-  backup_path="${file_path}.bak.$(date +%Y%m%d%H%M%S)"
+  backup_path="${target_path}.bak.$(date +%Y%m%d%H%M%S)"
 
-  if [ -f "$file_path" ]; then
+  if [ -e "$target_path" ]; then
     local backup_dir
     backup_dir=$(dirname "$backup_path")
 
-    local copy_cmd="cp"
+    local copy_cmd=(cp)
+    # Use sudo if destination dir is not writable
     if [ ! -w "$backup_dir" ]; then
-      copy_cmd="sudo cp"
+      copy_cmd=(sudo cp)
     fi
 
-    if $copy_cmd "$file_path" "$backup_path"; then
-      return 0
+    if [ -d "$target_path" ]; then
+      if "${copy_cmd[@]}" -a "$target_path" "$backup_path"; then
+        return 0
+      else
+        return 1
+      fi
     else
-      return 1
+      if "${copy_cmd[@]}" -a "$target_path" "$backup_path"; then
+        return 0
+      else
+        return 1
+      fi
     fi
   else
-    print_warning "File $file_path does not exist, skipping backup."
+    print_warning "Path $target_path does not exist, skipping backup."
   fi
 }
 
@@ -379,41 +388,46 @@ update_grub_cmdline() {
 }
 
 update_limine_cmdline() {
+  local dropin_name="$1"
+  if [[ -z "$dropin_name" ]]; then
+    print_error "update_limine_cmdline: drop-in filename is required (e.g., '50-hibernation.conf')"
+  fi
+  shift
+
   local params="$*"
-  local cmdline_file="/etc/kernel/cmdline"
+  # Ensure .conf suffix for convenience
+  [[ "$dropin_name" != *.conf ]] && dropin_name+=".conf"
 
-  print_info "Updating Limine kernel command line..."
+  local dropin_dir="/etc/limine-entry-tool.d"
 
-  local current_cmdline
-  current_cmdline=$(cat "$cmdline_file" 2>/dev/null)
+  if [[ ! -d "$dropin_dir" ]]; then
+    if not has_package "limine-mkinitcpio-hook"; then
+      print_info "Installing limine-mkinitcpio-hook for managing Limine drop-ins..."
+      install_package "limine-mkinitcpio-hook" || {
+      print_error "Failed to install limine-entry-tool. Cannot manage Limine drop-ins."
 
-  local new_cmdline
-  new_cmdline=$(_build_new_cmdline "$current_cmdline" "$params")
+      }
+    fi
+  fi
+  local dropin_file="$dropin_dir/$dropin_name"
 
-  if echo "$new_cmdline" | sudo tee "$cmdline_file" >/dev/null; then
-    print_info "Limine kernel command line updated."
+
+  print_info "Writing Limine drop-in: $(basename "$dropin_file")"
+
+  # Escape any double quotes in params to safely embed in quoted string
+  local escaped
+  escaped=$(printf '%s' "$params" | sed 's/"/\\"/g')
+
+  if sudo mkdir -p "$dropin_dir" && \
+   # must include += to append to existing KERNEL_CMDLINE else it will overwrite
+     printf 'KERNEL_CMDLINE[default]+= "%s"\n' "$escaped" | sudo tee "$dropin_file" >/dev/null; then
+    sudo chmod 0644 "$dropin_file" || true
+    print_info "Limine drop-in updated: $dropin_file"
   else
-    print_error "Failed to update Limine cmdline file."
+    print_error "Failed to write Limine drop-in: $dropin_file"
   fi
 }
 
-update_kernel_cmdline() {
-  local params="$*"
-  local bootloader
-  bootloader=$(detect_bootloader)
-
-  case "$bootloader" in
-  "limine")
-    update_limine_cmdline "$params"
-    ;;
-  "grub")
-    update_grub_cmdline "$params"
-    ;;
-  *)
-    print_warning "Unsupported bootloader, skipping kernel parameter update."
-    ;;
-  esac
-}
 
 regenerate_initramfs() {
   if [[ $(detect_bootloader) == "grub" ]]; then


### PR DESCRIPTION
This pull request refactors how kernel command line parameters are updated for different bootloaders (GRUB and Limine) in the Linux setup scripts. The main changes include replacing the generic `update_kernel_cmdline` function with explicit bootloader-specific logic, introducing robust Limine drop-in management, and improving backup and initialization procedures for Limine systems. These updates enhance maintainability, reliability, and support for systems using the Limine bootloader.

**Bootloader-specific kernel parameter updates:**

* Replaced the generic `update_kernel_cmdline` function with explicit case statements for GRUB and Limine in both `run_once_after_01_theming.sh` and `run_once_before_04_laptop.sh`, ensuring kernel parameters are updated appropriately for each bootloader.

**Limine drop-in management enhancements:**

* Refactored `update_limine_cmdline` to require a drop-in filename, ensure `.conf` suffix, install the necessary package if missing, and write kernel parameters as drop-ins in `/etc/limine-entry-tool.d`, supporting multiple drop-ins and safe quoting.
* Added logic to automatically create a default Limine drop-in (`01-default.conf`) from `/proc/cmdline` if missing, both during hibernation setup and theming, improving initialization for Limine systems. 
**Backup procedure improvements:**

* Updated the `create_backup` helper to back up directories as well as files, use more robust checks, and apply `sudo` when necessary, ensuring proper backup of Limine drop-in directories and kernel command line files. [[1]](diffhunk://#diff-ca35fcf4f1624c3fd1e412621bb96ae6096f93495967cbc9a27101020a409f9aL73-R101) [[2]](diffhunk://#diff-e39ca2b95cca0a6c3b01f2aa535e9fd109cd4bad1a9b487c9910e82a30ce7d71L183-R213)


**Minor code cleanups:**

* Removed unnecessary `return 1` statements after error messages for consistency and clarity.- Ensure Limine drop-in files are created if missing, sourcing from /proc/cmdline. -Use /proc/cmdline to get default kernel parameters instead of assuming UKI kernel is enabled

- This should fix issue #7