### PR TITLE
fix: correct window rule conditions and update script shebang

### DIFF
--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -30,7 +30,8 @@ diff:
   exclude:
     - "scripts"
 
-bitwarden: {{/* bw cli for secrets */}}
+{{/* bw cli for secrets */}}
+bitwarden:
   unlock: auto
   command: "{{ .chezmoi.homeDir }}/.local/bin/bw"
 

--- a/home/dot_config/hypr/hyprland/window-rules.conf
+++ b/home/dot_config/hypr/hyprland/window-rules.conf
@@ -137,8 +137,8 @@ windowrule = center 1, class:^(1Password)$
 
 $brave_popups = class:^(brave-browser)$, initialTitle:^(Untitled - Brave)$|^(PayPal - Brave)$
 windowrule = float, $brave_popups
-windowrule = float, title:^(Task Manager - Brave)$
-windowrule = size 70% 70%, title:^(Task Manager - Brave)$
+windowrule = float, initialTitle:^(Task Manager - Brave)$
+windowrule = size 70% 70%, initialTitle:^(Task Manager - Brave)$
 windowrule = size 30% 70%, $brave_popups
 windowrule = center 1, $brave_popups
 

--- a/home/dot_config/hypr/hyprland/window-rules.conf
+++ b/home/dot_config/hypr/hyprland/window-rules.conf
@@ -135,9 +135,9 @@ windowrule = size 60% 60%, class:^(1Password)$
 windowrule = center 1, class:^(1Password)$
 
 
-$brave_popups = class:^(brave-browser)$, title:^(Untitled - Brave)$|^(PayPal - Brave)$
+$brave_popups = class:^(brave-browser)$, initialTitle:^(Untitled - Brave)$|^(PayPal - Brave)$
 windowrule = float, $brave_popups
-windowrule = float, initialTitle:^(Task Manager - Brave)$
+windowrule = float, title:^(Task Manager - Brave)$
 windowrule = size 70% 70%, title:^(Task Manager - Brave)$
 windowrule = size 30% 70%, $brave_popups
 windowrule = center 1, $brave_popups

--- a/home/dot_config/shell/exportsrc
+++ b/home/dot_config/shell/exportsrc
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 # CLEANUP HOME DIRECTORY (XDG-compliant env vars)
 # ------------------------------------------------------------------------------
@@ -23,8 +23,9 @@ export __GL_SHADER_DISK_CACHE_PATH="${XDG_CACHE_HOME}/nv"
 export npm_config_cache="${XDG_CACHE_HOME}/npm"
 
 # wget alias with cache
-alias wget="wget --hsts-file=\"${XDG_CACHE_HOME}/wget-hsts\""
-
+wget() {
+  command wget --hsts-file="${XDG_CACHE_HOME}/wget-hsts" "$@"
+}
 # ------------------------------------------------------------------------------
 # DEFAULT ENVIRONMENT VARIABLES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

* Changed the shebang in `home/dot_config/shell/exportsrc` to use `/usr/bin/env bash` for better portability across systems.
* Replaced the wget alias in `home/dot_config/shell/exportsrc` with a shell function to ensure the custom `--hsts-file` argument is always used, regardless of how wget is invoked.

Window rule configuration updates:

* Updated Brave browser popup matching in `home/dot_config/hypr/hyprland/window-rules.conf` to use `initialTitle` instead of `title` for more accurate rule application, and adjusted the Task Manager rule for consistency.

Bitwarden CLI configuration:
* fix comment
