### PR TITLE
Updates

### DIFF
--- a/home/.chezmoiexternals/00-dms.yaml.tmpl
+++ b/home/.chezmoiexternals/00-dms.yaml.tmpl
@@ -5,7 +5,7 @@
   type: git-repo
   clone.args: "--depth=1"
   url: "https://github.com/vantesh/DankMaterialShell.git"
-  refreshPeriod: "36h"
+  refreshPeriod: "24h"
 
 {{- end }}
 {{ end }}


### PR DESCRIPTION
This pull request improves the reliability of hibernation setup for laptops using NVIDIA GPUs by ensuring the correct ordering of kernel modules in the `mkinitcpio` configuration. It also updates the refresh period for the external DankMaterialShell repository.

### Hibernation Setup Improvements

* Ensures NVIDIA modules (`nvidia`, `nvidia_modeset`, `nvidia_uvm`, `nvidia_drm`) are always listed before compression modules (`lz4`, `lz4_compress`) in the `MODULES` array within `mkinitcpio.conf`, which is critical for hibernation to work with NVIDIA GPUs. The script now detects ordering issues and rebuilds the list as needed.
* Adds logic to automatically include any missing NVIDIA or compression modules and only updates the configuration if changes are required, reducing unnecessary writes and potential errors.

### External Repository Configuration

* Changes the `refreshPeriod` for the DankMaterialShell external git repository from 36 hours to 24 hours, ensuring more frequent updates.