### PR TITLE
Escape Pango Characters. Added th_ch's YouTube Music client for detection.

### DIFF
--- a/home/dot_config/scripts/hyprlock/executable_current_song
+++ b/home/dot_config/scripts/hyprlock/executable_current_song
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 get_current_song() {
-  SPOTIFY_ICON="<span color='#a6e3a1'>󰓇 </span>"
-  FIREFOX_ICON="<span color='#f38ba8'> </span>"
-  VLC_ICON="<span color='#FFDB3C > 󰕼 </span>"
+  SPOTIFY_ICON="<span color='#A6E3A1'>󰓇 </span>"
+  FIREFOX_ICON="<span color='#F38BA8'> </span>"
+  VLC_ICON="<span color='#FFDB3C'>󰕼 </span>"
+  YOUTUBE_ICON="<span color='#FF0033'>  </span>"
 
   command -v playerctl &>/dev/null || exit 1
 
@@ -24,7 +25,20 @@ get_current_song() {
     -e 's/\s{2,}/ /g' \
     -e 's/^\s+|\s+$//g')
 
+  escape_pango() {
+    echo "$1" | sed \
+      -e 's/&/\&amp;/g' \
+      -e 's/</\&lt;/g' \
+      -e 's/>/\&gt;/g' \
+      -e 's/"/\&quot;/g' \
+      -e "s/'/\&apos;/g"
+  }
+
+  escape_artist=$(escape_pango "$artist")
+  escape_title=$(escape_pango "$cleaned_title")
+
   case "$current_player" in
+  *YoutubeMusic*) icon="$YOUTUBE_ICON" ;;
   *spotify*) icon="$SPOTIFY_ICON" ;;
   *mpv*) icon="" ;;
   *vlc*) icon="$VLC_ICON" ;;
@@ -34,11 +48,11 @@ get_current_song() {
   *) icon="" ;;
   esac
 
-  if [ -n "$cleaned_title" ]; then
-    if [[ -n "$artist" && "$cleaned_title" != *"$artist"* ]]; then
-      echo "$icon $artist - $cleaned_title"
+  if [ -n "$escape_title" ]; then
+    if [[ -n "$escape_artist" && "$escaped_title" != *"$escape_artist"* ]]; then
+      echo "$icon $escape_artist - $escape_title"
     else
-      echo "$icon $cleaned_title"
+      echo "$icon $escape_title"
     fi
   fi
 }


### PR DESCRIPTION
Currently the script doesn't escape Pango special characters `& < > ' "` when printing or echoing the currently playing song on the lock screen. This causes the span wrapping the icon to display as plain-text instead of rendering as the icon's color. 

I have added a function to escape those 5 special characters, to fix the rendering bug. 

You could see this bug when playing a song by the artist `MYTH & ROID` as an example. 

I also wanted to add YoutubeMusic to the detection of `$current_player`, since I use the third party player developed by th_ch called pear-desktop (recently renamed).

As an aside: I fixed some formatting in the ICON variable definitions.

I have tested my code. However, let me know if you have any issues.